### PR TITLE
Enable CTA-style experience cards with safe empty URL handling

### DIFF
--- a/src/app/components/card.tsx
+++ b/src/app/components/card.tsx
@@ -42,6 +42,7 @@ export const Card: NextPage<CardProps> = ({
     const cardClassName = classNames(`card-component mr-4 ml-4 mb-4 rounded shadow-md content-center`, customClassName);
     const linkProps = openInNewTab ? { target: "_blank", rel: "noopener noreferrer" } : { rel: "noopener" };
     const ctaText = buttonText ?? ctaLabel ?? "Learn More";
+    const hasNavigableUrl = url.trim().length > 0;
     const cardContent = (
         <div className={`p-4 rounded shadow-md bg-gray-200 hover:bg-gray-300 active:bg-gray-400 dark:bg-gray-900 ${backgroundTheme}`}>
             <h3 className="font-nyu-ultra font-extrabold uppercase text-overflow-ellipsis overflow-hidden line-clamp-2">
@@ -75,16 +76,18 @@ export const Card: NextPage<CardProps> = ({
                 <div className={cardClassName}>
                     {cardContent}
                 </div>
-                <Link
-                    className={classNames(
-                        buttonStyle,
-                        "-mt-3 w-1/2 hover:w-[70%] text-center font-nyu font-medium capitalize bg-purple-800 hover:bg-purple-900 text-white shadow-lg transition-all"
-                    )}
-                    href={url}
-                    {...linkProps}
-                >
-                    {ctaText}
-                </Link>
+                {hasNavigableUrl && (
+                    <Link
+                        className={classNames(
+                            buttonStyle,
+                            "-mt-3 w-1/2 hover:w-[70%] text-center font-nyu font-medium capitalize bg-purple-800 hover:bg-purple-900 text-white shadow-lg transition-all"
+                        )}
+                        href={url}
+                        {...linkProps}
+                    >
+                        {ctaText}
+                    </Link>
+                )}
             </div>
         );
     }

--- a/src/app/experiences/page.tsx
+++ b/src/app/experiences/page.tsx
@@ -209,7 +209,6 @@ export default function ExperiencesPage() {
           />
         </div>
 
-
         <div className={cardWrapperStyle}>
           <Card
             {...experienceCardProps}
@@ -253,7 +252,6 @@ export default function ExperiencesPage() {
             openInNewTab
           />
         </div>
-
 
         <div className={`${cardWrapperStyle}`}>
           <h3 className="text-xl font-bold text-center"> Other Experiences:</h3>

--- a/src/app/experiences/page.tsx
+++ b/src/app/experiences/page.tsx
@@ -38,7 +38,7 @@ export default function ExperiencesPage() {
             url="https://www.bonobos.com/"
             imageUrl="/bonobos-logo-dark.svg"
             backgroundTheme={`${nycBackgroundTheme}`}
-            description="Initially under Walmart Inc and then under Express LLC"
+            description="Initially under Walmart Inc and then under Express LLC. Responsible for front end technology projects."
           />
         </div>
 
@@ -49,7 +49,7 @@ export default function ExperiencesPage() {
             url="https://www.shoprunner.com/"
             imageUrl="/shoprunner_byfedex.svg"
             backgroundTheme={`${nycBackgroundTheme}`}
-            description="In a start up, and went through acquisition by FedEx"
+            description="In a start up, and went through acquisition by FedEx. WCAG Accessibility Expert! Promoted Twice."
           />
         </div>
 

--- a/src/app/experiences/page.tsx
+++ b/src/app/experiences/page.tsx
@@ -228,7 +228,7 @@ export default function ExperiencesPage() {
             url="https://web.uri.edu/business/about/tmd/"
             imageUrl="/uri.svg"
             backgroundTheme={`${nycBackgroundTheme}`}
-            description="Master of Science - Textiles, Fashion Merchandising & Design"
+            description={`Master of Science - Textiles, Fashion Merchandising & Design; Senator - Graduate Student Association`}
           />
         </div>
 
@@ -247,7 +247,7 @@ export default function ExperiencesPage() {
             {...experienceCardProps}
             title="Bangiya Sangeet Parishad"
             url="https://www.bangiyasangeetparishad.org/bsp/index.html"
-            imageUrl="https://placehold.co/300x300?text=Painting"
+            imageUrl="https://svt69ytw2j2onadk.public.blob.vercel-storage.com/BSP_Certificate_2nd_1996.png"
             backgroundTheme={`${nycBackgroundTheme}`}
             description="Diploma in Fine Arts, Painting (5th year) - Chitrankan Kala Mandir - Ranchi."
             openInNewTab

--- a/src/app/experiences/page.tsx
+++ b/src/app/experiences/page.tsx
@@ -3,6 +3,10 @@ import { Card } from "../components/card";
 import { buttonStyle, cardWrapperStyle, nycBackgroundTheme } from "../utility/stylevariables";
 
 export default function ExperiencesPage() {
+  const experienceCardProps = {
+    useCtaButton: true,
+  };
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-between pt-20 ">
       <div className="mb-32 grid text-center lg:w-half lg:max-w-5xl lg:grid-cols-3 lg:text-left">
@@ -18,6 +22,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Owner"
             url="/lotus"
             description="We are a boutique consulting studio helping organizations ship strategy & digital experiences"
@@ -28,6 +33,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Senior Software Engineer"
             url="https://www.bonobos.com/"
             imageUrl="/bonobos-logo-dark.svg"
@@ -38,6 +44,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Software Engineer 2"
             url="https://www.shoprunner.com/"
             imageUrl="/shoprunner_byfedex.svg"
@@ -48,6 +55,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Owner and CEO"
             url="/moc"
             imageUrl="https://live.staticflickr.com/65535/53808934296_8330a5b182_w.jpg"
@@ -59,6 +67,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Instructional Assistant"
             url=""
             imageUrl="northwestern.svg"
@@ -70,6 +79,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Department Chair - Fashion Marketing and Merchandising"
             url=""
             imageUrl="https://live.staticflickr.com/65535/53818079467_6eaf1c63ea_w.jpg"
@@ -82,6 +92,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Eye on India - The Saree Project (Co-ordinator)"
             url="/lotus/eye-on-india"
             imageUrl="https://live.staticflickr.com/65535/53839425086_c36fa84f70_w.jpg"
@@ -94,6 +105,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Assistant Professor, Fashion Studies."
             url=""
             imageUrl="https://live.staticflickr.com/65535/53819339684_9c2b53cb83_w.jpg"
@@ -106,6 +118,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="AT&T Samsung Galaxy Project"
             url="/lotus/samsung"
             imageUrl="https://live.staticflickr.com/65535/53851021701_6619ae0f97_w.jpg"
@@ -117,6 +130,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Docent - Lincoln Park Conservatory"
             url="/experiences/lincolnpark"
             imageUrl="https://live.staticflickr.com/65535/53863196190_faa7d80208_w.jpg"
@@ -128,6 +142,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Instructor - Family and Consumer Sciences"
             url=""
             imageUrl="/pittstate.svg"
@@ -140,6 +155,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="StyleWeek - PR Executive"
             url=""
             imageUrl="https://www.styleweeknortheast.com/wp-content/uploads/sites/26/2019/07/STYLEWEEK-LOGO-1.png"
@@ -151,6 +167,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Graduate Teaching Assistant"
             url=""
             imageUrl="/uri.svg"
@@ -161,6 +178,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Assistant Manager, Reliance Trends"
             url=""
             imageUrl="https://live.staticflickr.com/65535/53819337484_729e51ba15_w.jpg"
@@ -171,6 +189,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Reach Technologies"
             url=""
             imageUrl=""
@@ -181,6 +200,7 @@ export default function ExperiencesPage() {
         <h2 id="my-education" className="text-3xl font-bold text-center mt-8 font-nyu-ultra">Education</h2>
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="NYU - Stern School of Business"
             url="/nyu"
             imageUrl="/stern.png"
@@ -192,6 +212,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Northwestern University"
             url=""
             imageUrl="/northwestern.svg"
@@ -202,6 +223,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="University of Rhode Island - College of Business"
             url="https://web.uri.edu/business/about/tmd/"
             imageUrl="/uri.svg"
@@ -212,6 +234,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle} id="my-education-nift">
           <Card
+            {...experienceCardProps}
             title="National Institute of Fashion Technology"
             url="https://nift.ac.in/theinstitute"
             imageUrl="/nift.svg"
@@ -221,6 +244,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Bangiya Sangeet Parishad"
             url="https://www.bangiyasangeetparishad.org/bsp/index.html"
             imageUrl="https://placehold.co/300x300?text=Painting"
@@ -252,6 +276,7 @@ export default function ExperiencesPage() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...experienceCardProps}
             title="Download Resume Here"
             openInNewTab
             url="/resume"

--- a/src/app/experiences/page.tsx
+++ b/src/app/experiences/page.tsx
@@ -26,7 +26,7 @@ export default function ExperiencesPage() {
             title="Owner"
             url="/lotus"
             description="We are a boutique consulting studio helping organizations ship strategy & digital experiences"
-            customClassName={`${cardWrapperStyle}`}
+
             imageUrl="https://live.staticflickr.com/65535/53819325384_d2b8af917f_w.jpg"
           />
         </div>

--- a/src/app/nyu/page.tsx
+++ b/src/app/nyu/page.tsx
@@ -72,7 +72,7 @@ export default function NYUPage() {
   const renderSlide = () => {
     if (activeSlide === 0) {
       return (
-        <div className="grid md:grid-cols-2 gap-8 items-center">
+        <article className="grid md:grid-cols-2 gap-8 items-center rounded-2xl p-2">
           <div className="relative w-full max-w-[198px] md:max-w-[231px] aspect-[3/4] overflow-hidden rounded-2xl shadow-xl mx-auto md:mx-auto justify-self-center">
             <Image
               src="/class-rep.png"
@@ -94,7 +94,7 @@ export default function NYUPage() {
               This role keeps student voices at the center of every conversation with faculty and administration.
             </p>
           </div>
-        </div>
+        </article>
       );
     }
 
@@ -114,7 +114,7 @@ export default function NYUPage() {
                 <span className="absolute inset-0 bg-white/10 opacity-0 group-hover:opacity-100 transition" />
                 <span className="relative text-xl font-semibold">{area}</span>
                 <span className="relative block text-sm mt-2 opacity-75">
-                  Tap to expand (coming soon)
+                  Tap to view next snapshot
                 </span>
               </button>
             ))}
@@ -135,11 +135,14 @@ export default function NYUPage() {
               href={group.url}
               target="_blank"
               rel="noreferrer"
-              className="group block rounded-2xl border border-purple-200 dark:border-purple-900 bg-white dark:bg-purple-900/40 p-6 text-center shadow-md transition hover:-translate-y-1 hover:shadow-xl"
+              onClick={(event) => event.stopPropagation()}
+              className="group rounded-2xl border border-purple-200 dark:border-purple-900 bg-white dark:bg-purple-900/40 p-6 text-center shadow-md transition hover:-translate-y-1 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-purple-400"
             >
               <div className="text-3xl font-black tracking-tight text-purple-800 dark:text-purple-100">{group.short}</div>
               <div className="mt-3 font-semibold text-gray-800 dark:text-gray-100">{group.title}</div>
-              <span className="mt-2 inline-block text-sm text-purple-600 dark:text-purple-200 underline">Open in new tab</span>
+              <span className="mt-2 inline-block text-sm text-purple-600 dark:text-purple-200 underline">
+                Open in new tab
+              </span>
             </Link>
           ))}
         </div>
@@ -230,7 +233,19 @@ export default function NYUPage() {
               </div>
             </div>
 
-            <div className="relative mt-8 rounded-3xl border border-purple-100 dark:border-purple-900 bg-gradient-to-br from-purple-50 via-white to-purple-50 dark:from-[#0c041a] dark:via-[#0f0922] dark:to-[#160f2f] p-6 shadow-xl">
+            <div
+              className="relative mt-8 rounded-3xl border border-purple-100 dark:border-purple-900 bg-gradient-to-br from-purple-50 via-white to-purple-50 dark:from-[#0c041a] dark:via-[#0f0922] dark:to-[#160f2f] p-6 shadow-xl cursor-pointer focus:outline-none focus:ring-2 focus:ring-purple-400"
+              role="button"
+              tabIndex={0}
+              aria-label="Go to next Stern snapshot"
+              onClick={nextSlide}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  nextSlide();
+                }
+              }}
+            >
               <div className="relative min-h-[640px] md:min-h-[360px]">
                 {[0, 1, 2].map((index) => (
                   <div
@@ -252,7 +267,10 @@ export default function NYUPage() {
                   <button
                     key={index}
                     type="button"
-                    onClick={() => setActiveSlide(index)}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setActiveSlide(index);
+                    }}
                     className={classNames(
                       "h-2.5 w-2.5 rounded-full transition",
                       index === activeSlide

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -96,7 +96,6 @@ export default function Home() {
           })()}
           </div>
         
-
           <div className={cardWrapperStyle} id="aster">
             <h2 className="text-xl font-bold text-center capitalize" >Made in US Collaboration:</h2>
             <Card


### PR DESCRIPTION
Use this PR description:

**Title**  
Refine NYU Stern Snapshots card interactions and club link behavior

**Description**  
This PR updates interaction behavior on `/nyu` in `src/app/nyu/page.tsx` to make card behavior more consistent and intuitive.

### What changed
- Moved slide navigation click behavior to the entire **Stern Snapshots wrapper card**.
- Added keyboard support (`Enter` / `Space`) on that wrapper for accessibility.
- Kept slide-dot navigation working independently by stopping propagation on dot clicks.
- Updated **Clubs & Cohorts** so each full card is now a clickable external link.
- Club card links open in a new tab and no longer trigger slide-advance clicks.

### Why
- Aligns with expected UX: clicking the card area advances slides, while clicking club cards opens their associated links.

### Validation
- Lint passed:
  - `npm run lint -- --file src/app/nyu/page.tsx`

### Manual checks
- Clicking the Stern Snapshots wrapper advances to next slide.
- Dot controls jump to the selected slide without unintended next-slide behavior.
- Each Clubs & Cohorts card opens the correct URL in a new tab.