### PR TITLE
Update NYU Global Economy course highlight

### DIFF
--- a/src/app/nyu/projects-data.ts
+++ b/src/app/nyu/projects-data.ts
@@ -38,6 +38,12 @@ export const nyuCourses: NyuCourse[] = [
     projects: ["Financial Accounting Learnings"],
   },
   {
+    name: "The Global Economy",
+    passWithDistinction: true,
+    faculty: { name: "Julen Esteban-Pretel" },
+    projects: ["Macroscopic Analysis of Germany", "Analysis of China"],
+  },
+  {
     name: "Leadership in Organizations",
     faculty: {
       name: "Nathan Pettit",
@@ -57,11 +63,6 @@ export const nyuCourses: NyuCourse[] = [
     name: "Professional Responsibility",
     faculty: { name: "Alison Taylor", url: "https://www.alisontaylor.co/" },
     projects: ["What I learned from Whistleblowers?"],
-  },
-  {
-    name: "The Global Economy",
-    faculty: { name: "Julen Esteban-Pretel" },
-    projects: ["Macroscopic Analysis of Germany", "Analysis of China"],
   },
   {
     name: "Business Statistics and Data Analytics",


### PR DESCRIPTION
## Summary
- add the pass with distinction badge to The Global Economy
- move The Global Economy to the third position in the NYU course list

## Testing
- not run (data-only change)