### PR TITLE
Add three courses to NYU page with In-Progress badge

### DIFF
--- a/src/app/nyu/page.tsx
+++ b/src/app/nyu/page.tsx
@@ -353,6 +353,11 @@ export default function NYUPage() {
                               Langone (extra class)
                             </span>
                           )}
+                          {course.inProgress && (
+                            <span className="inline-flex items-center rounded-full bg-sky-300 px-3 py-1 text-xs font-semibold text-sky-950 shadow-sm">
+                              In-Progress
+                            </span>
+                          )}
                         </div>
                         {course.credits !== undefined && (
                           <div className="border border-white/80 dark:border-[#2e0068]/60 rounded-full px-2 py-1 text-right font-light leading-none shrink-0">
@@ -422,7 +427,7 @@ export default function NYUPage() {
 
       {activeProject && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-          <div className="w-full max-w-lg rounded-3xl bg-white p-6 text-gray-900 shadow-2xl dark:bg-zinc-950 dark:text-gray-100">
+          <div className="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-3xl bg-white p-6 text-gray-900 shadow-2xl dark:bg-zinc-950 dark:text-gray-100">
             <div className="flex items-start justify-between gap-4">
               <div>
                 <p className="text-xs uppercase tracking-[0.2em] text-purple-600 dark:text-purple-300">Project</p>

--- a/src/app/nyu/projects-data.ts
+++ b/src/app/nyu/projects-data.ts
@@ -2,6 +2,7 @@ export type NyuCourse = {
   name: string;
   passWithDistinction?: boolean;
   langoneExtraClass?: boolean;
+  inProgress?: boolean;
   credits?: number;
   faculty: { name: string; url?: string };
   projects: string[];
@@ -107,6 +108,36 @@ export const nyuCourses: NyuCourse[] = [
     },
     projects: [],
   },
+  {
+    name: "Foundations of Finance",
+    inProgress: true,
+    credits: 3,
+    faculty: {
+      name: "Alexi Savov",
+      url: "https://www.stern.nyu.edu/faculty/bio/alexi-savov",
+    },
+    projects: [],
+  },
+  {
+    name: "Marketing",
+    inProgress: true,
+    credits: 3,
+    faculty: {
+      name: "Thomaï Serdari",
+      url: "https://www.stern.nyu.edu/faculty/bio/thomai-serdari",
+    },
+    projects: ["Chelsea Piers Fitness"],
+  },
+  {
+    name: "Sustainability Value Creation in Private Markets",
+    langoneExtraClass: true,
+    credits: 3,
+    faculty: {
+      name: "Angela Jhanji",
+      url: "https://www.stern.nyu.edu/faculty/bio/angela-jhanji",
+    },
+    projects: [],
+  },
 ];
 
 export const nyuProjectInfo: Record<string, NyuProjectDetails> = {
@@ -180,6 +211,17 @@ export const nyuProjectInfo: Record<string, NyuProjectDetails> = {
       "Applied ratio and working-capital analysis to spot timing risk, estimate concentration, and potential distortions.",
     ],
     urls: [{ title: "Project page", url: "/nyu/financial-accounting" }],
+  },
+  "Chelsea Piers Fitness": {
+    description:
+      "CP Fitness is the fitness club arm of Chelsea Piers, the sports and entertainment complex on Manhattan's West Side. It sits in a crowded NYC premium fitness market with a brand identity tied to the larger Chelsea Piers name — known for multi-sport facilities and youth athletics — rather than a distinct luxury-fitness position of its own. The main ask: decide whether CP Fitness should lean into Chelsea Piers heritage, break out as a standalone luxury brand, or take a middle path — with the recommendation grounded in Millennial and Gen Z consumer analysis.",
+    outcomes: [
+      "Brand architecture is a positioning trade-off, not a naming exercise. Deciding between heritage, standalone luxury, and a hybrid path forced us to weigh the equity Chelsea Piers already owns against the premium associations it can't credibly claim — and the middle path only works if each sub-brand has a distinct job.",
+      "Consumer segmentation should drive strategy, not decorate it. Millennial and Gen Z fitness behaviors diverge enough (community vs. performance, price sensitivity vs. experience-seeking) that a single message dilutes both; the segment analysis is what disqualified the “one brand for everyone” option.",
+      "CLV discipline separates ambition from viability. Building the model on an incremental rather than fully loaded margin, and holding to a 3× LTV:CAC threshold, turned “should we expand?” into a defensible sequencing question about which five markets and in what order.",
+      "Partnerships extend a brand faster than advertising can. The Standard High Line × Malin+Goetz × Tracksmith concept borrowed credibility CP Fitness would take years and significant spend to build organically — the lesson being that the right collaborator is a positioning shortcut.",
+    ],
+    urls: [{ title: "Open project", url: "https://canva.link/l22n6v28cnf4n69" }],
   },
 };
 


### PR DESCRIPTION
Adds Foundations of Finance (Alexi Savov), Marketing (Thomai Serdari), and Sustainability Value Creation in Private Markets (Angela Jhanji), all 3 credits.

Marketing carries the Chelsea Piers Fitness project, covering brand architecture strategy for CP Fitness with four learning outcomes.

Introduces an `inProgress` course flag and matching badge, and caps the project modal at 90vh with overflow scrolling — the longer Chelsea Piers outcomes pushed the action buttons past the viewport with no way to reach them.