### PR TITLE
Rework /lotus header, cards, and add client logo strip

### DIFF
--- a/src/app/experiences/achievements/page.tsx
+++ b/src/app/experiences/achievements/page.tsx
@@ -193,6 +193,7 @@ const achievements = {
 const skillTiles: SkillTile[] = [
   { title: "Large-scale Store Launch", subtitle: "Reliance Trends · Marketing & Brand launches" },
   { title: "Pop-up Shop Launch", subtitle: "Lotus Mahal & Made of Chicago" },
+  { title: "Fashion Show Technical Producer", subtitle: "Drexel University" },
   { title: "Customer-facing Website Launch/Upgrade", subtitle: "Shoprunner" },
   { title: "Strategic Plan Implementation", subtitle: "Coppin State University" },
   { title: "Program Review Lead", subtitle: "Northwood University" },

--- a/src/app/lotus/page.tsx
+++ b/src/app/lotus/page.tsx
@@ -5,21 +5,72 @@ import { cardWrapperStyle, buttonStyle, tiffanyBackgroundTheme } from "../utilit
 import Link from "next/link";
 import Image from "next/image";
 
+// Add new clients here — the logo strip scrolls horizontally once they overflow.
+const clients = [
+  {
+    name: "Coppin State University",
+    logoUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRy1KBgM1GYf_60QUoKAWmTLEghgWRy7dqoEk6SWqyLXw&s=10",
+  },
+  {
+    name: "Drexel University",
+    logoUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQuWDwE_sobTkE9_-U3CpzEm209HvDj35hFzBMsW4xdYQ&s=10",
+  },
+  {
+    name: "Maryland",
+    logoUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ77cDrN_jUmmIBU4EodACtfguqPYJXhSR7i0Foz4T0Cw&s",
+  },
+];
+
 export default function Lotus() {
+  // Matches the homepage card treatment: card body stays a div and the link
+  // moves into a CTA button underneath.
+  const lotusCardProps = {
+    useCtaButton: true,
+  };
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-between pt-20 pb-20">
       <div className="mb-32 grid text-center lg:w-half lg:max-w-5xl lg:grid-cols-3 lg:text-left pb-60 px-6">
-        <h1 className="text-3xl font-bold text-center m-8 uppercase text-purple-800 font-nyu-ultra">Art & Design</h1>
+        <h1 className="text-3xl font-bold text-center m-8 uppercase text-purple-800 font-nyu-ultra">Welcome to The Lotus Mahal</h1>
         <h2 className="text-xl font-bold text-center m-8 dark:invert">
-          Welcome to the world of creativity and design.
+          a boutique consulting studio helping organizations ship strategy and digital experiences that actually work.
         </h2>
         <Card
+          {...lotusCardProps}
           title="Go to Lotus Mahal!"
           url="https://lotusmahal.com/"
+          buttonText="Visit Lotus Mahal"
           description="Lotus Mahal is dedicated to connecting people through the timeless art of letter writing in today's world."
           customClassName={`${cardWrapperStyle}`}
           imageUrl="https://live.staticflickr.com/65535/53819325384_d2b8af917f_w.jpg"
         />
+
+        {/* min-w-0 lets this grid item shrink below its content width, so the logo
+            row scrolls inside the rail instead of widening the whole page. */}
+        <section className="col-span-full min-w-0 my-8" aria-labelledby="clients-heading">
+          <h2 id="clients-heading" className="text-xl font-bold text-center capitalize mb-4">
+            Clients Include
+          </h2>
+          <div className="overflow-x-auto max-w-full pb-2">
+            <div className="flex gap-4 sm:gap-6 w-max mx-auto px-2">
+              {clients.map((client) => (
+                <div
+                  key={client.logoUrl}
+                  className="shrink-0 flex h-[90px] w-[160px] items-center justify-center rounded bg-white p-3 shadow-md"
+                >
+                  <Image
+                    className="max-h-full w-auto object-contain"
+                    src={client.logoUrl}
+                    alt={client.name}
+                    width={140}
+                    height={70}
+                    unoptimized
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
 
         <Tile
           title="Greeting Cards by Lotus Mahal"
@@ -74,8 +125,9 @@ export default function Lotus() {
 
         <div className="m-8">
           <Card
+            {...lotusCardProps}
             title="Coming soon: Fashion Business 101"
-            url="#"
+            url=""
             description="Start your Fashion Business and all you need to know! Coming in 2025!"
             customClassName="invert"
           >
@@ -85,8 +137,10 @@ export default function Lotus() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...lotusCardProps}
             title="Free Trivia for you to enjoy on the go!"
             url="/games/quiz"
+            buttonText="Play Trivia"
             imageUrl="/quiz.png"
             description="Version 1 is live! Version 2 coming soon!"
           />
@@ -94,8 +148,10 @@ export default function Lotus() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...lotusCardProps}
             title="Free Tic Tac Toe game for you to enjoy on the go!"
             url="/games/tic-tac-toe"
+            buttonText="Play Game"
             imageUrl="/tic-tac-toe.gif"
             description="Simple Tik Tac Toe Game for when you are bored."
           />
@@ -103,8 +159,10 @@ export default function Lotus() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...lotusCardProps}
             title="Basic Calculator"
             url="/tech/calculator"
+            buttonText="Open Calculator"
             description="Play around with a basic react Calculator"
           >
             <CalculatorIcon height="100px" width="100px" />
@@ -119,8 +177,9 @@ export default function Lotus() {
 
         <div className="m-8">
           <Card
+            {...lotusCardProps}
             title="Coming soon: Education Design"
-            url="#"
+            url=""
             description="Be 22nd century ready!"
             customClassName="invert"
           >
@@ -145,8 +204,10 @@ export default function Lotus() {
 
         <div>
           <Card
+            {...lotusCardProps}
             title="Commander&#x27;s palace mobile website"
             url="https://www.commanderspalace.com/"
+            buttonText="Visit Website"
             description="The video overviews the website I created as a technology consultant to Also Known as Studios, which designed Commander's Palace. I learned a new technology, Webflow. There were approximately 10 pages. The desktop and mobile designs are distinct. The current video shows the layout of the desktop version, which is managed by the restaurant itself. I also created learning items and materials to manage this beautiful but complex design."
             customClassName=""
           >
@@ -169,8 +230,10 @@ export default function Lotus() {
 
         <div className={cardWrapperStyle}>
           <Card
+            {...lotusCardProps}
             title="Commander's Palace Project"
             url="https://www.commanderspalace.com/"
+            buttonText="Visit Restaurant"
             openInNewTab
             backgroundTheme={tiffanyBackgroundTheme}
           >


### PR DESCRIPTION
Updates the page heading to "Welcome to The Lotus Mahal" and replaces the subheading with the consulting studio positioning.

Switches all 8 Card components to the homepage treatment (useCtaButton), so the card body is a div with a CTA button beneath it rather than the whole card being a link. This also fixes a real bug: two cards contained their own anchors — the Flickr embed and the Education Design link — which nested <a> inside <a> and broke hydration. Nested anchors on the page go from 2 to 0.

The two "Coming soon" cards previously used url="#", which in CTA mode would render a prominent button leading nowhere, so they now pass an empty url and render no button at all.

Adds a "Clients Include" logo strip between the Lotus Mahal card and the Greeting Cards tile, driven by a `clients` array so new clients are a one-line addition. The section carries min-w-0 because grid items default to min-width:auto, which would otherwise let the logo row widen the whole page instead of scrolling inside its rail.

The 6 image Tiles are intentionally left as they are.