### PR TITLE
Fix broken StyleWeek logo URL on /experiences

### DIFF
--- a/src/app/experiences/page.tsx
+++ b/src/app/experiences/page.tsx
@@ -158,7 +158,7 @@ export default function ExperiencesPage() {
             {...experienceCardProps}
             title="StyleWeek - PR Executive"
             url=""
-            imageUrl="https://www.styleweeknortheast.com/wp-content/uploads/sites/26/2019/07/STYLEWEEK-LOGO-1.png"
+            imageUrl="https://www.styleweeknortheast.com/wp-content/uploads/2019/07/STYLEWEEK-LOGO-1.png"
             imageHeight={200}
             imageWidth={190}
             description="PR + Fashion show production assistant."


### PR DESCRIPTION
The StyleWeek logo pointed at a /sites/26/ multisite path that now returns 404 with an HTML error page, so the card rendered with a broken image. Repointed to the current path, verified as HTTP 200 image/png before the swap.